### PR TITLE
order bounding box properties

### DIFF
--- a/pil_crop_image_block.py
+++ b/pil_crop_image_block.py
@@ -7,12 +7,14 @@ class PILCropImage(Block):
     """ Crop a PIL image to the specified region """
 
     version = VersionProperty("0.1.0")
-    left = IntProperty(title='Left Edge', default=0)
-    upper = IntProperty(title='Upper Edge', default=0)
+    left = IntProperty(title='Left Edge', default=0, order=0)
+    upper = IntProperty(title='Upper Edge', default=0, order=1)
     right = IntProperty(title='Right Edge',
-                        default='{{ min($image.width, $image.height) }}')
+                        default='{{ min($image.width, $image.height) }}',
+                        order=2)
     lower = IntProperty(title='Lower Edge',
-                        default='{{ min($image.width, $image.height) }}')
+                        default='{{ min($image.width, $image.height) }}',
+                        order=3)
 
     def process_signals(self, signals, input_id='default'):
         for signal in signals:


### PR DESCRIPTION
this is the order `Image.crop` takes args, looks much better in the designer ordered this way
https://pillow.readthedocs.io/en/5.1.x/reference/Image.html#PIL.Image.Image.crop